### PR TITLE
Adds schema config

### DIFF
--- a/config/install/auto_entitylabel.settings.node.person.yml
+++ b/config/install/auto_entitylabel.settings.node.person.yml
@@ -1,7 +1,7 @@
-status: '1'
+status: 1
 pattern: '[node:field_person_preferred_name:given] [node:field_person_preferred_name:middle] [node:field_person_preferred_name:family]'
-php: 0
-escape: 0
+php: false
+escape: false
 dependencies:
   config:
     - node.type.person

--- a/config/install/core.entity_view_display.node.cat_geographic_location.default.yml
+++ b/config/install/core.entity_view_display.node.cat_geographic_location.default.yml
@@ -38,9 +38,9 @@ content:
     weight: 1
     label: inline
     settings:
-      trim_length: '80'
-      url_only: ''
-      url_plain: ''
+      trim_length: 80
+      url_only: false
+      url_plain: false
       rel: ''
       target: _blank
     third_party_settings: {  }

--- a/config/install/core.entity_view_display.node.corporate_body.default.yml
+++ b/config/install/core.entity_view_display.node.corporate_body.default.yml
@@ -69,9 +69,9 @@ content:
     weight: 1
     label: above
     settings:
-      trim_length: '80'
-      url_only: ''
-      url_plain: ''
+      trim_length: 80
+      url_only: false
+      url_plain: false
       rel: ''
       target: _blank
     third_party_settings: {  }

--- a/config/install/core.entity_view_display.node.family.default.yml
+++ b/config/install/core.entity_view_display.node.family.default.yml
@@ -19,9 +19,9 @@ content:
     weight: 10
     label: above
     settings:
-      trim_length: '80'
-      url_only: ''
-      url_plain: ''
+      trim_length: 80
+      url_only: false
+      url_plain: false
       rel: ''
       target: _blank
     third_party_settings: {  }

--- a/config/install/core.entity_view_display.node.person.default.yml
+++ b/config/install/core.entity_view_display.node.person.default.yml
@@ -81,9 +81,9 @@ content:
     weight: 2
     label: above
     settings:
-      trim_length: '80'
-      url_only: ''
-      url_plain: ''
+      trim_length: 80
+      url_only: false
+      url_plain: false
       rel: ''
       target: _blank
     third_party_settings: {  }

--- a/config/install/core.entity_view_display.node.subject.default.yml
+++ b/config/install/core.entity_view_display.node.subject.default.yml
@@ -25,9 +25,9 @@ content:
     weight: 103
     label: above
     settings:
-      trim_length: '80'
-      url_only: ''
-      url_plain: ''
+      trim_length: 80
+      url_only: false
+      url_plain: false
       rel: ''
       target: _blank
     third_party_settings: {  }

--- a/config/schema/controlled_access_terms.schema.yml
+++ b/config/schema/controlled_access_terms.schema.yml
@@ -13,3 +13,84 @@ field.field_settings.authority_link:
     link_type:
       type: integer
       label: 'Allowed link type'
+
+field.widget.settings.authority_link_default:
+  type: mapping
+  label: 'Link format settings'
+  mapping:
+    placeholder_url:
+      type: string
+      label: 'Placeholder for URL'
+    placeholder_title:
+      type: label
+      label: 'Placeholder for link text'
+
+field.widget.settings.text_edtf:
+  type: mapping
+  link: ''
+  mapping:
+    strict_dates:
+      type: boolean
+      label: 'Strict Dates Required'
+    intervals:
+      type: boolean
+      label: 'Intervals Permitted'
+
+field.widget.settings.text_date:
+  type: mapping
+  link: ''
+  mapping:
+    strict_dates:
+      type: boolean
+      label: 'Strict Dates Required'
+    date_format:
+      type: string
+      label: 'Date String Format'
+
+field.formatter.settings.authority_formatter_default:
+  type: mapping
+  label: 'Authority Link format settings'
+  mapping:
+    trim_length:
+      type: integer
+      label: 'Trim link text length'
+    url_only:
+      type: boolean
+      label: 'URL only'
+    url_plain:
+      type: boolean
+      label: 'Show URL as plain text'
+    rel:
+      type: string
+      label: 'Add rel="nofollow" to links'
+    target:
+      type: string
+      label: 'Open link in new window'
+
+field.formatter.settings.text_edtf_human:
+  type: mapping
+  label: 'EDTF for humans format settings'
+  mapping:
+    date_separator:
+      type: string
+      label: 'Date separator'
+    date_order:
+      type: string
+      label: 'Date Order'
+    month_format:
+      type: string
+      label: 'Month Format'
+    day_format:
+      type: string
+      label: 'Day Format'
+    season_hemisphere:
+      type: string
+      label: 'Hemisphere Seasons'
+
+field.formatter.settings.text_edtf_iso8601:
+  type: mapping
+  label: 'EDTF ISO8601 format settings'
+  mapping:
+    season_hemisphere:
+      type: string
+      label: 'Hemisphere Seasons'

--- a/config/schema/controlled_access_terms.schema.yml
+++ b/config/schema/controlled_access_terms.schema.yml
@@ -1,0 +1,15 @@
+field.field_settings.authority_link:
+  type: mapping
+  label: 'Authority Link settings'
+  mapping:
+    authority_sources:
+      type: sequence
+      label: 'Authority Sources'
+      sequence:
+        - type: string
+    title:
+      type: integer
+      label: 'Allow link text'
+    link_type:
+      type: integer
+      label: 'Allowed link type'

--- a/config/schema/controlled_access_terms.schema.yml
+++ b/config/schema/controlled_access_terms.schema.yml
@@ -94,3 +94,29 @@ field.formatter.settings.text_edtf_iso8601:
     season_hemisphere:
       type: string
       label: 'Hemisphere Seasons'
+
+auto_entitylabel.settings.node.person:
+  type: mapping
+  mapping:
+    status:
+      type: integer
+      label: 'Automatic label generation'
+    pattern:
+      type: string
+      label: 'Pattern for the label'
+    php:
+      type: boolean
+      label: 'Use PHP for auto entity labels'
+    escape:
+      type: boolean
+      label: 'Escape special characters'
+    dependencies:
+      type: config_dependencies
+      label: 'Dependencies'
+    _core:
+      type: mapping
+      mapping:
+        default_config_hash:
+          type: string
+    langcode:
+      type: string


### PR DESCRIPTION
GitHub Issues: Islandora-CLAW/CLAW#901 and Islandora-CLAW/CLAW#902

## What does this Pull Request do?

Adds `config/schema/controlled_access_terms.schema.yml` and updates the related config/install/ authority link configurations to match.

## What's new?
- Does this change require documentation to be updated? no
- Does this change add any new dependencies? no
- Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? no
- Could this change impact execution of existing code? no

## How should this be tested?

- Install [config_inspector](https://www.drupal.org/project/config_inspector)
- Apply this PR to controlled_access_terms
- Enable both controlled_access_terms and config_inspector
- Navigate to `/admin/config/development/configuration/inspect`
- There should be no errors reported (at least for items related to this module).

## Interested parties

@Natkeeran @dannylamb 