### PR TITLE
fix validateValues

### DIFF
--- a/src/Plugin/Field/FieldType/AuthorityLink.php
+++ b/src/Plugin/Field/FieldType/AuthorityLink.php
@@ -148,7 +148,7 @@ class AuthorityLink extends LinkItem {
   /**
    * An #element_validate callback function.
    *
-   * @param \Drupal\controlled_access_terms\Plugin\Field\FieldType\AuthorityLink $element
+   * @param array $element
    *   An associative array containing the properties and children of the
    *   generic form element.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
@@ -156,7 +156,7 @@ class AuthorityLink extends LinkItem {
    *
    * @see \Drupal\Core\Render\Element\FormElement::processPattern()
    */
-  public static function validateValues(AuthorityLink $element, FormStateInterface $form_state) {
+  public static function validateValues(array $element, FormStateInterface $form_state) {
     $values = static::extractPipedValues($element['#value']);
 
     if (!is_array($values)) {


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/911

# What does this Pull Request do?

Corrects the validateVales function call so that it accepts an array rather than an AuthorityLink instance.

# How should this be tested?

* Before applying the PR, attempting to update any of the AuthorityLink fields' "Authority Source" configurations would fail. E.g. @ `/admin/structure/types/manage/subject/fields/node.subject.field_subject_authorities` add 'blah|Blah` to "Authority Sources" and clicking "Save settings" will die.
* Apply the PR then try to save the same form again. It should work now.

# Interested parties
@Islandora-CLAW/committers