### PR TITLE
correct broken validateValues

### DIFF
--- a/src/Plugin/Field/FieldType/TypedRelation.php
+++ b/src/Plugin/Field/FieldType/TypedRelation.php
@@ -164,7 +164,7 @@ class TypedRelation extends EntityReferenceItem {
   /**
    * Callback for settings form.
    *
-   * @param \Drupal\Core\Render\Element\FormElement $element
+   * @param array $element
    *   An associative array containing the properties and children of the
    *   generic form element.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
@@ -172,7 +172,7 @@ class TypedRelation extends EntityReferenceItem {
    *
    * @see \Drupal\Core\Render\Element\FormElement::processPattern()
    */
-  public static function validateValues(FormElement $element, FormStateInterface $form_state) {
+  public static function validateValues(array $element, FormStateInterface $form_state) {
     $values = static::extractPipedValues($element['#value']);
 
     if (!is_array($values)) {

--- a/src/Plugin/Field/FieldType/TypedRelation.php
+++ b/src/Plugin/Field/FieldType/TypedRelation.php
@@ -5,7 +5,6 @@ namespace Drupal\controlled_access_terms\Plugin\Field\FieldType;
 use Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem;
 use Drupal\Core\Field\FieldStorageDefinitionInterface;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Render\Element\FormElement;
 use Drupal\Core\TypedData\DataDefinition;
 
 /**


### PR DESCRIPTION
**GitHub Issue**: [issues/915](https://github.com/Islandora-CLAW/CLAW/issues/915)

# What does this Pull Request do?

Fixes a broken validateValues function in the TypedRelation FieldType.

# What's new?
Corrected the function call argument type FormElement to array.

# How should this be tested?

* With Controlled Access Terms enabled, try to correct the default values for a typed relation field => WSOD
* Apply the PR
* Try again => No WSOD and the values update.

# Interested parties
@Islandora-CLAW/committers