### PR TITLE
Part of Issue 888

### DIFF
--- a/modules/controlled_access_terms_default_configuration/config/install/field.field.taxonomy_term.resource_types.field_external_authority_link.yml
+++ b/modules/controlled_access_terms_default_configuration/config/install/field.field.taxonomy_term.resource_types.field_external_authority_link.yml
@@ -1,0 +1,27 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_external_authority_link
+    - taxonomy.vocabulary.resource_types
+  module:
+    - islandora_demo
+    - controlled_access_terms
+id: taxonomy_term.resource_types.field_external_authority_link
+field_name: field_external_authority_link
+entity_type: taxonomy_term
+bundle: resource_types
+label: 'External Authority Link'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  authority_sources:
+    dcmi_types: 'DCMI Type Vocabulary'
+    marc_resource_types: 'MARC Resource Types'
+    other: Other
+  title: 1
+  link_type: 16
+field_type: authority_link

--- a/modules/controlled_access_terms_default_configuration/config/install/field.field.taxonomy_term.resource_types.field_external_authority_link.yml
+++ b/modules/controlled_access_terms_default_configuration/config/install/field.field.taxonomy_term.resource_types.field_external_authority_link.yml
@@ -5,7 +5,6 @@ dependencies:
     - field.storage.taxonomy_term.field_external_authority_link
     - taxonomy.vocabulary.resource_types
   module:
-    - islandora_demo
     - controlled_access_terms
 id: taxonomy_term.resource_types.field_external_authority_link
 field_name: field_external_authority_link

--- a/modules/controlled_access_terms_default_configuration/config/install/field.storage.taxonomy_term.field_external_authority_link.yml
+++ b/modules/controlled_access_terms_default_configuration/config/install/field.storage.taxonomy_term.field_external_authority_link.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - controlled_access_terms
+    - taxonomy
+id: taxonomy_term.field_external_authority_link
+field_name: field_external_authority_link
+entity_type: taxonomy_term
+type: authority_link
+settings: {  }
+module: islandora_demo
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/controlled_access_terms_default_configuration/config/install/taxonomy.vocabulary.resource_types.yml
+++ b/modules/controlled_access_terms_default_configuration/config/install/taxonomy.vocabulary.resource_types.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'Resource Types'
+vid: resource_types
+description: 'See http://purl.org/dc/dcmitype/ and http://id.loc.gov/vocabulary/resourceTypes.html (a nested list of types).'
+hierarchy: 0
+weight: 0


### PR DESCRIPTION
Part of Islandora-CLAW/CLAW#888

Takes the `resource_type` vocabulary out of `islandora_demo` and into `controlled_access_terms_default_configuration`