### PR TITLE
remove islandora_demo dependency in field.storage.taxonomy_term.field_external_authority_link

### DIFF
--- a/modules/controlled_access_terms_default_configuration/config/install/field.storage.taxonomy_term.field_external_authority_link.yml
+++ b/modules/controlled_access_terms_default_configuration/config/install/field.storage.taxonomy_term.field_external_authority_link.yml
@@ -9,7 +9,7 @@ field_name: field_external_authority_link
 entity_type: taxonomy_term
 type: authority_link
 settings: {  }
-module: islandora_demo
+module: core
 locked: false
 cardinality: 1
 translatable: true


### PR DESCRIPTION
**GitHub Issue**: Islandora-CLAW/CLAW/issues/967 and Islandora-CLAW/CLAW/issues/968

# What does this Pull Request do?

Removes a dependency on islandora_demo that lingered after the move from said module.

# What's new?

changed module config value "islandora_demo" to "core" (same as the other field storage configs) in field.storage.taxonomy_term.field_external_authority_link

# How should this be tested?

* Fresh claw_playbook should fail on "Import JWT Config Into Drupal"
* Apply the PR to the module
* Import changes using the Controlled Access Terms bundle in Features.
* Retry the provision; everything should be happy.

# Interested parties
@dannylamb 