### PR TITLE
Adding rdf mapping for resource_types

### DIFF
--- a/modules/controlled_access_terms_default_configuration/config/install/rdf.mapping.taxonomy_term.resource_types.yml
+++ b/modules/controlled_access_terms_default_configuration/config/install/rdf.mapping.taxonomy_term.resource_types.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.resource_types
+  module:
+    - taxonomy
+id: taxonomy_term.resource_types
+targetEntityType: taxonomy_term
+bundle: resource_types
+types:
+  - 'schema:Thing'
+fieldMappings:
+  name:
+    properties:
+      - 'schema:name'
+  description:
+    properties:
+      - 'schema:description'
+  field_authority_link:
+    properties:
+      - 'schema:sameAs'


### PR DESCRIPTION
Part of https://github.com/Islandora-CLAW/CLAW/issues/990, which has the testing instructions for this and all other related PRs.

Adds an rdf mapping that was missing.