### PR TITLE
Update EDTF field for 2018 spec compliance

### DIFF
--- a/controlled_access_terms.module
+++ b/controlled_access_terms.module
@@ -73,6 +73,40 @@ function controlled_access_terms_jsonld_alter_normalized_array(EntityInterface $
   }
 }
 
+
+/**
+ * Update EDTF fields from the 2012 draft to match the 2018 spec.
+ */
+function controlled_access_terms_update_8003() {
+  $db = \Drupal::database();
+
+  // Find all the fields using edtf.
+  $config_factory = \Drupal::configFactory();
+  foreach ($config_factory->listAll('field.storage.') as $field_storage_config_name) {
+    $field_storage_config = $config_factory->get($field_storage_config_name);
+    if ($field_storage_config->get('type') === 'edtf'){
+
+      // Run through each update. Make sure 'unknown' is updated before 'u'.
+      $updates = [
+        'open' => '..',
+        'unknown' => '',
+        'y' => 'Y',
+        'u' => 'X',
+        '?~' => '%',
+        '~?' => '%',
+      ];
+      foreach ($updates as $old => $new) {
+        $db->update($field_storage_config->get('entity_type') . '__' . $field_storage_config->get('field_name'))
+        ->expression($field_storage_config->get('field_name') . '_value', 'replace('. $field_storage_config->get('field_name') . '_value, :old, :new)', [
+          ':old' => $old,
+          ':new' => $new
+        ])
+        ->execute();
+      }
+    }
+  }
+}
+
 /**
  * Change fields using the EDTF Widget to the new EDTF Field Type.
  */

--- a/controlled_access_terms.module
+++ b/controlled_access_terms.module
@@ -73,7 +73,6 @@ function controlled_access_terms_jsonld_alter_normalized_array(EntityInterface $
   }
 }
 
-
 /**
  * Update EDTF fields from the 2012 draft to match the 2018 spec.
  */
@@ -84,7 +83,7 @@ function controlled_access_terms_update_8003() {
   $config_factory = \Drupal::configFactory();
   foreach ($config_factory->listAll('field.storage.') as $field_storage_config_name) {
     $field_storage_config = $config_factory->get($field_storage_config_name);
-    if ($field_storage_config->get('type') === 'edtf'){
+    if ($field_storage_config->get('type') === 'edtf') {
 
       // Run through each update. Make sure 'unknown' is updated before 'u'.
       $updates = [
@@ -97,11 +96,11 @@ function controlled_access_terms_update_8003() {
       ];
       foreach ($updates as $old => $new) {
         $db->update($field_storage_config->get('entity_type') . '__' . $field_storage_config->get('field_name'))
-        ->expression($field_storage_config->get('field_name') . '_value', 'replace('. $field_storage_config->get('field_name') . '_value, :old, :new)', [
-          ':old' => $old,
-          ':new' => $new
-        ])
-        ->execute();
+          ->expression($field_storage_config->get('field_name') . '_value', 'replace(' . $field_storage_config->get('field_name') . '_value, :old, :new)', [
+            ':old' => $old,
+            ':new' => $new,
+          ])
+          ->execute();
       }
     }
   }

--- a/modules/controlled_access_terms_default_configuration/config/install/core.entity_view_display.taxonomy_term.corporate_body.default.yml
+++ b/modules/controlled_access_terms_default_configuration/config/install/core.entity_view_display.taxonomy_term.corporate_body.default.yml
@@ -45,7 +45,6 @@ content:
       date_order: big_endian
       month_format: mm
       day_format: dd
-      season_hemisphere: north
     third_party_settings: {  }
     type: edtf_default
     region: content
@@ -57,7 +56,6 @@ content:
       date_order: big_endian
       month_format: mm
       day_format: dd
-      season_hemisphere: north
     third_party_settings: {  }
     type: edtf_default
     region: content

--- a/modules/controlled_access_terms_default_configuration/config/install/core.entity_view_display.taxonomy_term.family.default.yml
+++ b/modules/controlled_access_terms_default_configuration/config/install/core.entity_view_display.taxonomy_term.family.default.yml
@@ -42,7 +42,6 @@ content:
       date_order: big_endian
       month_format: mm
       day_format: dd
-      season_hemisphere: north
     third_party_settings: {  }
     type: edtf_default
     region: content
@@ -54,7 +53,6 @@ content:
       date_order: big_endian
       month_format: mm
       day_format: dd
-      season_hemisphere: north
     third_party_settings: {  }
     type: edtf_default
     region: content

--- a/modules/controlled_access_terms_default_configuration/config/install/core.entity_view_display.taxonomy_term.person.default.yml
+++ b/modules/controlled_access_terms_default_configuration/config/install/core.entity_view_display.taxonomy_term.person.default.yml
@@ -45,7 +45,6 @@ content:
       date_order: little_endian
       month_format: mmm
       day_format: dd
-      season_hemisphere: north
     third_party_settings: {  }
     type: edtf_default
     region: content
@@ -57,7 +56,6 @@ content:
       date_order: little_endian
       month_format: mmm
       day_format: dd
-      season_hemisphere: north
     third_party_settings: {  }
     type: edtf_default
     region: content

--- a/src/EDTFConverter.php
+++ b/src/EDTFConverter.php
@@ -10,40 +10,6 @@ use Drupal\rdf\CommonDataConverter;
 class EDTFConverter extends CommonDataConverter {
 
   /**
-   * Northern hemisphere season map.
-   *
-   * @var array
-   */
-  private $seasonMapNorth = [
-  // Spring => March.
-    '21' => '03',
-  // Summer => June.
-    '22' => '06',
-  // Autumn => September.
-    '23' => '09',
-  // Winter => December.
-    '24' => '12',
-  ];
-
-  /**
-   * Southern hemisphere season map.
-   *
-   * (Currently unused until a config for this is established.)
-   *
-   * @var array
-   */
-  private $seasonMapSouth = [
-  // Spring => September.
-    '21' => '03',
-  // Summer => December.
-    '22' => '06',
-  // Autumn => March.
-    '23' => '09',
-  // Winter => June.
-    '24' => '12',
-  ];
-
-  /**
    * Converts an EDTF text field into an ISO 8601 timestamp string.
    *
    * It assumes the earliest valid date for approximations and intervals.
@@ -55,19 +21,11 @@ class EDTFConverter extends CommonDataConverter {
    *   Returns the ISO 8601 timestamp.
    */
   public static function datetimeIso8601Value(array $data) {
-    $date = explode('/', $data['value'])[0];
 
-    // Strip approximations/uncertainty.
-    $date = str_replace(['?', '~'], '', $date);
+    // Take first possible date.
+    $date = preg_split('/(,|\.\.|\/)/', trim($data['value'], '{}[]'))[0];
 
-    // Replace unspecified.
-    // Month/day.
-    $date = str_replace('-uu', '-01', $date);
-    // Zero-Year in decade/century.
-    $date = str_replace('u', '0', $date);
-
-    // Seasons map.
-    return EDTFConverter::seasonsMap($date) . 'T00:00:00';
+    return EDTFUtils::iso8601Value($date);
 
   }
 
@@ -83,43 +41,8 @@ class EDTFConverter extends CommonDataConverter {
    *   Returns the ISO 8601 date.
    */
   public static function dateIso8601Value(array $data) {
-    $date = explode('/', $data['value'])[0];
 
-    // Strip approximations/uncertainty.
-    $date = str_replace(['?', '~'], '', $date);
-
-    // Remove unspecified.
-    // Month/day.
-    $date = str_replace('-uu', '', $date);
-    // Zero-Year in decade/century.
-    $date = str_replace('u', '0', $date);
-
-    // Seasons map.
-    return EDTFConverter::seasonsMap($date);
-
-  }
-
-  /**
-   * Converts a numeric season into a numeric month.
-   *
-   * @param string $date
-   *   The date string to convert.
-   *
-   * @return string
-   *   Returns the ISO 8601 date with the correct month.
-   */
-  protected static function seasonsMap(string $date) {
-    $date_parts[] = explode('-', $date, 3);
-    // Digit Seasons.
-    if ((count($date_parts) > 1) &&
-        in_array($date_parts[1], ['21', '22', '23', '24'])) {
-      // TODO: Make hemisphere seasons configurable.
-      $season_mapping = $seasonMapNorth;
-      $date_parts[1] = $season_mapping[$date_parts[1]];
-      $date = implode('-', array_filter($date_parts));
-    }
-
-    return $date;
+    return explode('T', EDTFConverter::datetimeIso8601Value($data))[0];
 
   }
 

--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -1,0 +1,235 @@
+<?
+
+namespace Drupal\controlled_access_terms;
+
+use Datetime;
+
+/**
+ * Utility functions for working with Extended Date Time Format.
+ */
+class EDTFUtils {
+
+  // EDTF Date Parse REGEX Array Positions.
+  const DATE_PARSE_REGEX = '([%\?~])?(-?Y?-?([\dX]+)(E\d)?(S\d)?)([%\?~])?-?([%\?~])?([\dX]{2})?([%\?~])?-?([%\?~])?([\dX]{2})?([%\?~])?';
+  const FULL_MATCH             =  0;
+  const QUALIFIER_YEAR_ONLY    =  1;
+  const YEAR_FULL              =  2;
+  const YEAR_BASE              =  3;
+  const YEAR_EXPONENT          =  4;
+  const YEAR_SIGNIFICANT_DIGIT =  5;
+  const QUALIFIER_YEAR         =  6;
+  const QUALIFIER_MONTH_ONLY   =  7;
+  const MONTH                  =  8;
+  const QUALIFIER_MONTH        =  9;
+  const QUALIFIER_DAY_ONLY     = 10;
+  const DAY                    = 11;
+  const QUALIFIER_DAY          = 12;
+
+  /**
+   * Month/Season to text map.
+   *
+   * @var array
+   */
+  const MONTHS_MAP = [
+    '01' => ['mmm' => 'Jan', 'mmmm' => 'January'],
+    '02' => ['mmm' => 'Feb', 'mmmm' => 'February'],
+    '03' => ['mmm' => 'Mar', 'mmmm' => 'March'],
+    '04' => ['mmm' => 'Apr', 'mmmm' => 'April'],
+    '05' => ['mmm' => 'May', 'mmmm' => 'May'],
+    '06' => ['mmm' => 'Jun', 'mmmm' => 'June'],
+    '07' => ['mmm' => 'Jul', 'mmmm' => 'July'],
+    '08' => ['mmm' => 'Aug', 'mmmm' => 'August'],
+    '09' => ['mmm' => 'Sep', 'mmmm' => 'September'],
+    '10' => ['mmm' => 'Oct', 'mmmm' => 'October'],
+    '11' => ['mmm' => 'Nov', 'mmmm' => 'November'],
+    '12' => ['mmm' => 'Dec', 'mmmm' => 'December'],
+    '21' => ['mmm' => 'Spr', 'mmmm' => 'Spring'],
+    '22' => ['mmm' => 'Sum', 'mmmm' => 'Summer'],
+    '23' => ['mmm' => 'Aut', 'mmmm' => 'Autumn'],
+    '24' => ['mmm' => 'Win', 'mmmm' => 'Winter'],
+    '25' => ['mmm' => 'Spr', 'mmmm' => 'Spring - Northern Hemisphere'],
+    '26' => ['mmm' => 'Sum', 'mmmm' => 'Summer - Northern Hemisphere'],
+    '27' => ['mmm' => 'Aut', 'mmmm' => 'Autumn - Northern Hemisphere'],
+    '28' => ['mmm' => 'Win', 'mmmm' => 'Winter - Northern Hemisphere'],
+    '29' => ['mmm' => 'Spr', 'mmmm' => 'Spring - Southern Hemisphere'],
+    '30' => ['mmm' => 'Sum', 'mmmm' => 'Summer - Southern Hemisphere'],
+    '31' => ['mmm' => 'Aut', 'mmmm' => 'Autumn - Southern Hemisphere'],
+    '32' => ['mmm' => 'Win', 'mmmm' => 'Winter - Southern Hemisphere'],
+    '33' => ['mmm' => 'Q1', 'mmmm' => 'Quarter 1'],
+    '34' => ['mmm' => 'Q2', 'mmmm' => 'Quarter 2'],
+    '35' => ['mmm' => 'Q3', 'mmmm' => 'Quarter 3'],
+    '36' => ['mmm' => 'Q4', 'mmmm' => 'Quarter 4'],
+    // I'm making up the rest of these abbreviations
+    // because I can't find standardized ones.
+    '37' => ['mmm' => 'Quad1', 'mmmm' => 'Quadrimester 1'],
+    '38' => ['mmm' => 'Quad2', 'mmmm' => 'Quadrimester 2'],
+    '39' => ['mmm' => 'Quad3', 'mmmm' => 'Quadrimester 3'],
+    '40' => ['mmm' => 'Sem1', 'mmmm' => 'Semestral 1'],
+    '41' => ['mmm' => 'Sem2', 'mmmm' => 'Semestral 2'],
+  ];
+
+
+  /**
+   * Validate an EDTF expression.
+   *
+   * @param string $edtf_text
+   *   The datetime string.
+   *
+   * @return array
+   *   Array of error messages. Valid if empty.
+   */
+  public static function validate($edtf_text, $intervals = TRUE, $sets = TRUE, $strict = FALSE) {
+    $msgs = [];
+    // Sets.
+    if ($sets) {
+      if (strpos($edtf_text, '[') !== FALSE || strpos($edtf_text, '{') !== FALSE) {
+        // Test for valid enclosing characters and valid characters inside.
+        $match = preg_match('/^([\[,\{])[\d,\-,X,Y,E,S,.]*([\],\}])$/', $edtf_text);
+        if (!$match || $match[1] !== $match[2]) {
+          $msgs[] = "The set is improperly encoded.";
+        }
+        // Test each date in set.
+        foreach (preg_split('/(,|\.\.)/', trim($edtf_text, '{}[]')) as $date) {
+          $msgs = array_merge($msgs, self::validate_date($date, $strict));
+        }
+        return $msgs;
+      }
+    }
+    // Intervals.
+    if ($intervals) {
+      if (strpos($edtf_text, 'T') !== FALSE) {
+        $msgs[] = "Date intervals cannot include times.";
+      }
+      foreach (explode('/', $$edtf_text) as $date) {
+        if (!empty($date) && !$date === '..') {
+          $msgs = array_merge($msgs, self::validate_date($date, $strict));
+        }
+      }
+      return $msgs;
+    }
+    // Single date (we assume at this point).
+    return self::validate_date($edtf_text, $strict);
+  }
+
+  /**
+   * Validate a single date.
+   *
+   * @param string $datetime_str
+   *   The datetime string.
+   *
+   * @return array
+   *   Array of error messages. Valid if empty.
+   */
+  public static function validate_date($datetime_str, $strict = FALSE) {
+    $msgs = [];
+
+    list($date, $time) = explode('T', $datetime_str);
+
+    preg_match(self::DATE_PARSE_REGEX, $date, $parsed_date);
+
+    // "Something" is wrong with the provided date if it doesn't round-trip.
+    // Includes (non-exhaustive):
+    //   - no invalid characters present,
+    //   - two-digit months and days, and
+    //   - capturing group qualifiers.
+    if ($date !== $parsed_date[self::FULL_MATCH]) {
+      $msgs[] = ["Could not parse the date '$date'",];
+    }
+
+    // Year.
+    if ((strpos($parsed_date[self::YEAR_FULL], 'Y') === 0) {
+      if ($strict){
+        $msgs[] = ["Extended years are not supported with the 'strict dates' option enabled."];
+      }
+      // Expand exponents.
+      if (!empty($parsed_date[self::YEAR_EXPONENT])) {
+        $exponent = intval(substr($parsed_date[self::YEAR_EXPONENT], 1));
+        $parsed_date[self::YEAR_BASE] = strval((10 ** $exponent) * intval($parsed_date[self::YEAR_BASE]));
+        $parsed_date[self::YEAR_BASE] = self::expand_year($parsed_date[self::YEAR_FULL], $parsed_date[self::YEAR_BASE], $parsed_date[self::YEAR_EXPONENT]);
+      }
+    } elseif (length($parsed_date[self::YEAR_BASE]) > 4) {
+      $msgs[] = ["Years longer than 4 digits must be prefixed with a 'Y'."];
+    } elseif (length($parsed_date[self::YEAR_BASE]) < 4) {
+      $msgs[] = ["Years must be at least 4 characters long."];
+    }
+    $strict_pattern = 'Y'
+
+    // Month.
+    if (!array_key_exists(self::MONTH, $parsed_date) && !empty($parsed_date[self::MONTH])) {
+      // Valid month values?
+      if (!array_key_exists($parsed_date[self::MONTH], self::MONTHS_MAP) &&
+          strpos($parsed_date[self::MONTH], 'X') === FALSE ) {
+        $msgs[] = ["Provided month value '$parsed_date[self::MONTH]' is not valid."];
+      }
+      $strict_pattern = 'Y-m';
+    }
+
+    // Day.
+    if (!array_key_exists(self::DAY) && !empty($parsed_date[self::DAY])) {
+      // Valid day values?
+      if (strpos($parsed_date[self::DAY], 'X') === FALSE &&
+          !in_array(intval($parsed_date[self::DAY]), range(1, 31))) {
+        $msgs[] = ["Provided day value '$parsed_date[self::DAY]' is not valid."];
+      }
+      $strict_pattern = 'Y-m-d';
+    }
+    // Time.
+    if (strpos($datetime_str, 'T') !== FALSE && empty($time)) {
+      $msgs[] = "Time not provided with time seperator (T).";
+    }
+
+    if ($time) {
+      if (!preg_match('/^-?(\d{4})(-\d{2}){2}T\d{2}(:\d{2}){2}(Z|(\+|-)\d{2}:\d{2})?$/', $datetime_str, $matches)) {
+        $msgs[] = "The date/time '$datetime_str' is invalid.";
+      }
+      $strict_pattern = 'Y-m-d\TH:i:s';
+      if (count($matches) > 4) {
+        if ($matches[4] === 'Z') {
+          $strict_pattern .= '\Z';
+        }
+        else {
+          $strict_pattern .= 'P';
+        }
+      }
+    }
+
+    if ($strict) {
+      // Assemble the parts again.
+      if ($time) {
+        $cleaned_datetime = $datetime_str;
+      } else {
+        $cleaned_datetime = implode('-', [
+          $parsed_date[self::YEAR_BASE],
+          $parsed_date[self::MONTH],
+          $parsed_date[self::DAY],
+        ]);
+      }
+      $datetime_obj = DateTime::createFromFormat('!' . $strict_pattern, $cleaned_datetime);
+      $errors = DateTime::getLastErrors();
+      if (!$datetime_obj ||
+          !empty($errors['warning_count']) ||
+          // DateTime will create valid dates from Y-m without warning,
+          // so validate we still have what it was given.
+          !($cleaned_datetime === $datetime_obj->format($strict_pattern))
+        ) {
+        $msgs[] = "Strictly speaking, the date (and/or time) '$datetime_str' is invalid.";
+      }
+    }
+
+    return $msgs;
+  }
+
+  public static function expand_year($year_full, $year_base, $year_exponent){
+    $year = '';
+    // Apply negative to base.
+    // Note that the minus sign can be before or after the 'Y'
+    // in the full date field; thus, simply check not FALSE.
+    if (strpos($year_full,'-') !== FALSE) {
+      $year = '-';
+    }
+    // Expand exponents.
+    $exponent = intval(substr($year_exponent, 1));
+    $year .= strval((10 ** $exponent) * intval($year_base));
+  }
+
+}

--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -68,6 +68,54 @@ class EDTFUtils {
     '41' => ['mmm' => 'Sem2', 'mmmm' => 'Semestral 2'],
   ];
 
+  const SEASONS_MAP = [
+    // Northern Hemisphere bias for 21-24.
+    '21' => '03',
+    '22' => '06',
+    '23' => '09',
+    '24' => '12',
+    // Northern seasons.
+    '25' => '03',
+    '26' => '06',
+    '27' => '09',
+    '28' => '12',
+    // Southern seasons.
+    '29' => '09',
+    '30' => '12',
+    '31' => '03',
+    '32' => '06',
+    // Quarters.
+    '33' => '01',
+    '34' => '04',
+    '35' => '07',
+    '36' => '10',
+    // Quadrimesters.
+    '37' => '01',
+    '38' => '05',
+    '39' => '09',
+    // Semesters.
+    '40' => '01',
+    '41' => '07',
+  ];
+
+  /**
+   * Southern hemisphere season map.
+   *
+   * (Currently unused until a config for this is established.)
+   *
+   * @var array
+   */
+  private $seasonMapSouth = [
+  // Spring => September.
+    '21' => '03',
+  // Summer => December.
+    '22' => '06',
+  // Autumn => March.
+    '23' => '09',
+  // Winter => June.
+    '24' => '12',
+  ];
+
   /**
    * Validate an EDTF expression.
    *
@@ -252,6 +300,59 @@ class EDTFUtils {
     else {
       return $year_base;
     }
+  }
+
+  /**
+   * Converts an EDTF string into an ISO 8601 timestamp string.
+   *
+   * @param string $edtf
+   *   The array containing the 'value' element.
+   *
+   * @return string
+   *   Returns the ISO 8601 timestamp.
+   */
+  public static function iso8601Value(string $edtf) {
+
+    $date_time = explode('T', $edtf);
+
+    preg_match(EDTFUtils::DATE_PARSE_REGEX, $date_time[0], $parsed_date);
+
+    $year = '';
+    $month = '';
+    $day = '';
+
+    $parsed_date[EDTFUtils::YEAR_BASE] = EDTFUtils::expandYear($parsed_date[EDTFUtils::YEAR_FULL], $parsed_date[EDTFUtils::YEAR_BASE], $parsed_date[EDTFUtils::YEAR_EXPONENT]);
+
+    // Clean-up unspecified year/decade.
+    $year = str_replace('X', '0', $parsed_date[EDTFUtils::YEAR_BASE]);
+
+    if (array_key_exists(EDTFUtils::MONTH, $parsed_date)) {
+      $month = str_replace('XX', '01', $parsed_date[EDTFUtils::MONTH]);
+      $month = str_replace('X', '0', $month);
+
+      // ISO 8601 doesn't support seasonal notation yet. Swap them out.
+      if (array_key_exists($month, EDTFUtils::SEASONS_MAP)) {
+        $month = EDTFUtils::SEASONS_MAP[$month];
+      }
+    }
+
+    if (array_key_exists(EDTFUtils::DAY, $parsed_date)) {
+      $day = str_replace('XX', '01', $parsed_date[EDTFUtils::DAY]);
+      $day = str_replace('X', '0', $day);
+    }
+
+    $formatted_date = implode('-', array_filter([$year, $month, $day]));
+
+    // Time.
+    if (array_key_exists(1, $date_time) && !empty($date_time[1])) {
+      $formatted_date .= 'T' . $date_time[1];
+    }
+    else {
+      $formatted_date .= 'T00:00:00';
+    }
+
+    return $formatted_date;
+
   }
 
 }

--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -95,7 +95,9 @@ class EDTFUtils {
         }
         // Test each date in set.
         foreach (preg_split('/(,|\.\.)/', trim($edtf_text, '{}[]')) as $date) {
-          $msgs = array_merge($msgs, self::validateDate($date, $strict));
+          if (!empty($date)) {
+            $msgs = array_merge($msgs, self::validateDate($date, $strict));
+          }
         }
         return $msgs;
       }

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -5,6 +5,7 @@ namespace Drupal\controlled_access_terms\Plugin\Field\FieldFormatter;
 use Drupal\Core\Field\FormatterBase;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\controlled_access_terms\EDTFUtils;
 
 /**
  * Plugin implementation of the 'TextEDTFFormatter'.
@@ -20,49 +21,6 @@ use Drupal\Core\Form\FormStateInterface;
  * )
  */
 class EDTFFormatter extends FormatterBase {
-
-  /**
-   * Month/Season to text map.
-   *
-   * @var array
-   */
-  private $MONTHS = [
-    '01' => ['mmm' => 'Jan', 'mmmm' => 'January'],
-    '02' => ['mmm' => 'Feb', 'mmmm' => 'February'],
-    '03' => ['mmm' => 'Mar', 'mmmm' => 'March'],
-    '04' => ['mmm' => 'Apr', 'mmmm' => 'April'],
-    '05' => ['mmm' => 'May', 'mmmm' => 'May'],
-    '06' => ['mmm' => 'Jun', 'mmmm' => 'June'],
-    '07' => ['mmm' => 'Jul', 'mmmm' => 'July'],
-    '08' => ['mmm' => 'Aug', 'mmmm' => 'August'],
-    '09' => ['mmm' => 'Sep', 'mmmm' => 'September'],
-    '10' => ['mmm' => 'Oct', 'mmmm' => 'October'],
-    '11' => ['mmm' => 'Nov', 'mmmm' => 'November'],
-    '12' => ['mmm' => 'Dec', 'mmmm' => 'December'],
-    '21' => ['mmm' => 'Spr', 'mmmm' => 'Spring'],
-    '22' => ['mmm' => 'Sum', 'mmmm' => 'Summer'],
-    '23' => ['mmm' => 'Aut', 'mmmm' => 'Autumn'],
-    '24' => ['mmm' => 'Win', 'mmmm' => 'Winter'],
-    '25' => ['mmm' => 'Spr', 'mmmm' => 'Spring - Northern Hemisphere'],
-    '26' => ['mmm' => 'Sum', 'mmmm' => 'Summer - Northern Hemisphere'],
-    '27' => ['mmm' => 'Aut', 'mmmm' => 'Autumn - Northern Hemisphere'],
-    '28' => ['mmm' => 'Win', 'mmmm' => 'Winter - Northern Hemisphere'],
-    '29' => ['mmm' => 'Spr', 'mmmm' => 'Spring - Southern Hemisphere'],
-    '30' => ['mmm' => 'Sum', 'mmmm' => 'Summer - Southern Hemisphere'],
-    '31' => ['mmm' => 'Aut', 'mmmm' => 'Autumn - Southern Hemisphere'],
-    '32' => ['mmm' => 'Win', 'mmmm' => 'Winter - Southern Hemisphere'],
-    '33' => ['mmm' => 'Q1', 'mmmm' => 'Quarter 1'],
-    '34' => ['mmm' => 'Q2', 'mmmm' => 'Quarter 2'],
-    '35' => ['mmm' => 'Q3', 'mmmm' => 'Quarter 3'],
-    '36' => ['mmm' => 'Q4', 'mmmm' => 'Quarter 4'],
-    // I'm making up the rest of these abbreviations
-    // because I can't find standardized ones.
-    '37' => ['mmm' => 'Quad1', 'mmmm' => 'Quadrimester 1'],
-    '38' => ['mmm' => 'Quad2', 'mmmm' => 'Quadrimester 2'],
-    '39' => ['mmm' => 'Quad3', 'mmmm' => 'Quadrimester 3'],
-    '40' => ['mmm' => 'Sem1', 'mmmm' => 'Semestral 1'],
-    '41' => ['mmm' => 'Sem2', 'mmmm' => 'Semestral 2'],
-  ];
 
   /**
    * Various delimiters.
@@ -214,94 +172,78 @@ class EDTFFormatter extends FormatterBase {
    *   The date in EDTF format.
    */
   protected function formatDate($edtf_text) {
+
+    list($date, $time) = explode('T', $datetime_str);
+
+    // Formatted versions of the date elements.
+    $year = '';
+    $month = '';
+    $day = '';
+
+    preg_match(EDTFUtils::DATE_PARSE_REGEX, $date, $parsed_date);
+    $parsed_date[EDTFUtils::YEAR_BASE] = EDTFUtils::expand_year($parsed_date[EDTFUtils::YEAR_FULL], $parsed_date[EDTFUtils::YEAR_BASE], $parsed_date[EDTFUtils::YEAR_EXPONENT]);
     $settings = $this->getSettings();
-    $cleaned_datetime = $edtf_text;
-    // TODO: Time?
-    $qualifiers_format = '%s';
-    // Uncertainty.
-    // TODO: Group Qualification
-    if (!(strpos($edtf_text, '~') === FALSE)) {
-      $qualifiers_format = t('approximately');
-      $qualifiers_format .= ' %s';
-    }
-    if (!(strpos($edtf_text, '?') === FALSE)) {
-      $qualifiers_format = '%s ';
-      $qualifiers_format .= t('(uncertain)');
-    }
-    if (!(strpos($edtf_text, '%') === FALSE)) {
-      $qualifiers_format = '%s ';
-      $qualifiers_format .= t('(approximate and uncertain)');
-    }
-    $cleaned_datetime = str_replace(['?', '~', '%'], '', $cleaned_datetime);
 
-    list($year, $month, $day) = explode('-', $cleaned_datetime, 3);
-
-    // Which unspecified, if any?
-    $which_unspecified = '';
-    if (!(strpos($year, 'XX') === FALSE)) {
-      $which_unspecified = t('decade');
+    // Unspecified.
+    $unspecified = [];
+    if (strpos($parsed_date[EDTFUtils::YEAR_BASE], 'XXXX') !== FALSE) {
+      $unspecified[] = t('year');
     }
-    if (!(strpos($year, 'X') === FALSE)) {
-      $which_unspecified = t('year');
+    elseif (strpos($parsed_date[EDTFUtils::YEAR_BASE], 'XXX') !== FALSE) {
+      $unspecified[] = t('century');
     }
-    if (!(strpos($month, 'X') === FALSE)) {
-      $which_unspecified = t('month');
-      // No partial months.
-      $month = '';
+    elseif (strpos($parsed_date[EDTFUtils::YEAR_BASE], 'XX') !== FALSE) {
+      $unspecified[] = t('decade');
     }
-    if (!(strpos($day, 'X') === FALSE)) {
-      $which_unspecified = t('day');
-      // No partial days.
-      $day = '';
+    elseif (strpos($parsed_date[EDTFUtils::YEAR_BASE], 'XXXX') !== FALSE) {
+      $unspecified[] = t('year');
     }
-    // Add unspecified formatting if needed.
-    if (!empty($which_unspecified)) {
-      $qualifiers_format = t('an unspecified @part in', ['@part' => $which_unspecified]) . ' ' . $qualifiers_format;
-    }
-
     // Clean-up unspecified year/decade.
-    if (!(strpos($year, 'X') === FALSE)) {
-      $year = str_replace('X', '0', $year);
-      $year = t("the @year's", ['@year' => $year]);
-    }
+    $year = str_replace('X', '0', $parsed_date[EDTFUtils::YEAR_BASE]);
 
-    // Format the month.
-    if (!empty($month)) {
+    if (array_key_exists(self::MONTH, $parsed_date) && strpos($parsed_date[EDTFUtils::MONTH], 'X') !== FALSE) {
+      $unspecified[] = t('month');
       // IF 'mm', do nothing, it is already in this format.
       if ($settings['month_format'] === 'mmm' || $settings['month_format'] === 'mmmm') {
-        $month = $this->MONTHS[$month][$settings['month_format']];
+        $month = EDTFUtils::MONTHS_MAP[$parsed_date[EDTFUtils::MONTH]][$settings['month_format']];
       }
       if ($settings['month_format'] === 'm') {
-        $month = ltrim($month, ' 0');
+        $month = ltrim($parsed_date[EDTFUtils::MONTH], ' 0');
       }
     }
-
-    // Format the day.
-    if (!empty($day)) {
+    if (array_key_exists(self::DAY, $parsed_date) && strpos($parsed_date[EDTFUtils::DAY], 'X') !== FALSE) {
+      $unspecified[] = t('day');
       if ($settings['day_format'] === 'd') {
-        $day = ltrim($day, ' 0');
+        $day = ltrim($parsed_date[EDTFUtils::DAY], ' 0');
+      }
+      else {
+        $day = $parsed_date[EDTFUtils::DAY];
       }
     }
 
-    // Put the parts back together
-    // Big Endian by default.
-    $parts_in_order = [$year, $month, $day];
-
+    // TODO: Qualified.
+    // Put the parts back together.
     if ($settings['date_order'] === 'little_endian') {
       $parts_in_order = [$day, $month, $year];
     }
     elseif ($settings['date_order'] === 'middle_endian') {
       $parts_in_order = [$month, $day, $year];
-    } // Big Endian by default
-
-    if ($settings['date_order'] === 'middle_endian' && !preg_match('/\d/', $month) && !empty(array_filter([$month, $day]))) {
-      $cleaned_datetime = "$month $day, $year";
     }
     else {
-      $cleaned_datetime = implode($this->DELIMITERS[$settings['date_separator']], array_filter($parts_in_order));
+      // Big Endian by default.
+      $parts_in_order = [$year, $month, $day];
     }
 
-    return sprintf($qualifiers_format, $cleaned_datetime);
+    if ($settings['date_order'] === 'middle_endian' && !preg_match('/\d/', $month) && !empty(array_filter([$month, $day]))) {
+      $formatted_date = "$month $day, $year";
+    }
+    else {
+      $formatted_date = implode($this->DELIMITERS[$settings['date_separator']], array_filter($parts_in_order));
+    }
+
+    // TODO: Time.
+    // Return sprintf($qualifiers_format, $formatted_date);.
+    return $formatted_date;
   }
 
 }

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -229,14 +229,15 @@ class EDTFFormatter extends FormatterBase {
     if (array_key_exists(EDTFUtils::MONTH, $parsed_date)) {
       if (strpos($parsed_date[EDTFUtils::MONTH], 'X') !== FALSE) {
         $unspecified[] = t('month');
+        // Month remains blank for output.
       }
-      // IF 'mm', do nothing, it is already in this format.
-      if ($settings['month_format'] === 'mmm' || $settings['month_format'] === 'mmmm') {
+      elseif ($settings['month_format'] === 'mmm' || $settings['month_format'] === 'mmmm') {
         $month = EDTFUtils::MONTHS_MAP[$parsed_date[EDTFUtils::MONTH]][$settings['month_format']];
       }
       elseif ($settings['month_format'] === 'm') {
         $month = ltrim($parsed_date[EDTFUtils::MONTH], ' 0');
       }
+      // IF 'mm', do nothing, it is already in this format.
       else {
         $month = $parsed_date[EDTFUtils::MONTH];
       }

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -197,14 +197,14 @@ class EDTFFormatter extends FormatterBase {
    */
   protected function formatDate($edtf_text) {
 
-    list($date, $time) = explode('T', $edtf_text);
+    $date_time = explode('T', $edtf_text);
 
     // Formatted versions of the date elements.
     $year = '';
     $month = '';
     $day = '';
 
-    preg_match(EDTFUtils::DATE_PARSE_REGEX, $date, $parsed_date);
+    preg_match(EDTFUtils::DATE_PARSE_REGEX, $date_time[0], $parsed_date);
 
     $parsed_date[EDTFUtils::YEAR_BASE] = EDTFUtils::expandYear($parsed_date[EDTFUtils::YEAR_FULL], $parsed_date[EDTFUtils::YEAR_BASE], $parsed_date[EDTFUtils::YEAR_EXPONENT]);
     $settings = $this->getSettings();
@@ -276,8 +276,8 @@ class EDTFFormatter extends FormatterBase {
 
     // Time.
     // TODO: Add time formatting options.
-    if (isset($time) && !empty($time)) {
-      $formatted_date .= ' ' . $time;
+    if (array_key_exists(1, $date_time) && !empty($date_time[1])) {
+      $formatted_date .= ' ' . $date_time[1];
     }
 
     // Unspecified.

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -153,13 +153,15 @@ class EDTFFormatter extends FormatterBase {
             case 2:
               if (empty($date_range[0])) {
                 $formatted_dates[] = t('@date or some earlier date', [
-                  '@date' => $this->formatDate($date_range[1])
+                  '@date' => $this->formatDate($date_range[1]),
                 ]);
-              } elseif (empty($date_range[1])) {
+              }
+              elseif (empty($date_range[1])) {
                 $formatted_dates[] = t('@date or some later date', [
-                  '@date' => $this->formatDate($date_range[0])
+                  '@date' => $this->formatDate($date_range[0]),
                 ]);
-              } else {
+              }
+              else {
                 $formatted_dates[] = t('@date_begin until @date_end', [
                   '@date_begin' => $this->formatDate($date_range[0]),
                   '@date_end' => $this->formatDate($date_range[1]),

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -143,8 +143,30 @@ class EDTFFormatter extends FormatterBase {
       // Sets.
       if (strpos($item->value, '[') !== FALSE || strpos($item->value, '{') !== FALSE) {
         $set_qualifier = (strpos($item->value, '[') !== FALSE) ? t('one of the dates:') : t('all of the dates:');
-        foreach (preg_split('/(,|\.\.)/', trim($item->value, '{}[]')) as $date) {
-          $formatted_dates[] = $this->formatDate($date);
+        foreach (explode(',', trim($item->value, '{}[] ')) as $date) {
+          $date_range = explode('..', $date);
+          switch (count($date_range)) {
+            case 1:
+              $formatted_dates[] = $this->formatDate($date);
+              break;
+
+            case 2:
+              if (empty($date_range[0])) {
+                $formatted_dates[] = t('@date or some earlier date', [
+                  '@date' => $this->formatDate($date_range[1])
+                ]);
+              } elseif (empty($date_range[1])) {
+                $formatted_dates[] = t('@date or some later date', [
+                  '@date' => $this->formatDate($date_range[0])
+                ]);
+              } else {
+                $formatted_dates[] = t('@date_begin until @date_end', [
+                  '@date_begin' => $this->formatDate($date_range[0]),
+                  '@date_end' => $this->formatDate($date_range[1]),
+                ]);
+              }
+              break;
+          }
         }
         $element[$delta] = [
           '#markup' => t('@qualifier @list', [

--- a/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
+++ b/src/Plugin/Field/FieldType/ExtendedDateTimeFormat.php
@@ -9,7 +9,7 @@ use Drupal\Core\Field\Plugin\Field\FieldType\StringItem;
  *
  * @FieldType(
  *   id = "edtf",
- *   label = @Translation("EDTF, level 1"),
+ *   label = @Translation("EDTF"),
  *   module = "controlled_access_terms",
  *   description = @Translation("Extended Date Time Format field"),
  *   default_formatter = "edtf_default",

--- a/src/Plugin/Field/FieldWidget/EDTFWidget.php
+++ b/src/Plugin/Field/FieldWidget/EDTFWidget.php
@@ -10,10 +10,8 @@ use Drupal\Core\Form\FormStateInterface;
 /**
  * Plugin implementation of the 'edtf' widget.
  *
- * Validates text values for compliance with EDTF 1.0, level 1.
- * http://www.loc.gov/standards/datetime/pre-submission.html.
- *
- * // TODO: maybe some day support level 2.
+ * Validates text values for compliance with EDTF (2018).
+ * https://www.loc.gov/standards/datetime/edtf.html.
  *
  * @FieldWidget(
  *   id = "edtf_default",
@@ -32,6 +30,7 @@ class EDTFWidget extends WidgetBase {
     return [
       'strict_dates' => FALSE,
       'intervals' => FALSE,
+      'sets' => FALSE,
     ] + parent::defaultSettings();
   }
 
@@ -40,21 +39,19 @@ class EDTFWidget extends WidgetBase {
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
     $description_string = $this->t(
-        'Negative dates, and the level 1 features unspecified dates,
-        extended years, and seasons
-        are not supported with strict date checking.'
+        'Most level 1 and 2 features are not supported with strict date checking.'
     );
     $description_string .= ' <br /> ';
     $description_string .= $this->t(
       'Uncertain/Approximate dates will have their markers removed before
-        checking. (For example, "1984~?" will be checked as "1984".)'
+        checking. (For example, "1984?", "1984~", and "1984%" will be checked as "1984".)'
     );
     $element = parent::settingsForm($form, $form_state);
     $element['description'] = [
       '#type' => 'markup',
       '#prefix' => '<div>',
       '#suffix' => '</div>',
-      '#markup' => $this->t('See <a href="@locedtf" target="_blank">Library of Congress EDTF Draft Submission</a> for details on formatting options.', ['@locedtf' => 'http://www.loc.gov/standards/datetime/pre-submission.html']),
+      '#markup' => $this->t('See <a href="@locedtf" target="_blank">Library of Congress EDTF Specification</a> for details on formatting options.', ['@locedtf' => 'https://www.loc.gov/standards/datetime/edtf.html']),
     ];
     $element['strict_dates'] = [
       '#type' => 'checkbox',
@@ -66,6 +63,11 @@ class EDTFWidget extends WidgetBase {
       '#type' => 'checkbox',
       '#title' => $this->t('Permit date intervals.'),
       '#default_value' => $this->getSetting('intervals'),
+    ];
+    $element['sets'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Permit date sets. (Not recommended; make the field repeatable instead.)'),
+      '#default_value' => $this->getSetting('sets'),
     ];
     return $element;
   }
@@ -84,6 +86,12 @@ class EDTFWidget extends WidgetBase {
     }
     else {
       $summary[] = t('Date intervals are not permitted');
+    }
+    if ($this->getSetting('sets')) {
+      $summary[] = t('Date sets permitted');
+    }
+    else {
+      $summary[] = t('Date sets are not permitted');
     }
 
     return $summary;
@@ -115,33 +123,48 @@ class EDTFWidget extends WidgetBase {
       $form_state->setValueForElement($element, '');
       return;
     }
-
+    // No whitespace.
+    if (preg_match('/\s/', $value) !== FALSE) {
+      $form_state->setError($element, t("Dates cannot include spaces."));
+      return;
+    }
+    // Sets.
+    if ($this->getSetting('sets')) {
+      if (strpos($value, '[') !== FALSE || strpos($value, '{') !== FALSE) {
+        // Test for valid enclosing characters and valid characters inside.
+        $match = preg_match('/^([\[,\{])[\d,\-,X,Y,E,S,.]*([\],\}])$/', $value);
+        if (!$match || $match[1] !== $match[2]) {
+          $form_state->setError($element, t("The set is improperly encoded."))
+        }
+        // Test each date in set.
+        foreach (preg_split('/(,|\.\.)/', trim($value, '{}[]')) as $date) {
+          $error_message = $this->dateValidation($date);
+          if ($error_message) {
+            $form_state->setError($element, $error_message);
+          }
+        }
+        return;
+      }
+    }
     // Intervals.
     if ($this->getSetting('intervals')) {
       if (strpos($value, 'T') !== FALSE) {
         $form_state->setError($element, t("Date intervals cannot include times."));
       }
-
-      list($begin, $end) = explode('/', $value);
-      // Begin.
-      $error_message = $this->dateValidation($begin);
-      if ($error_message) {
-        $form_state->setError($element, $error_message);
+      foreach (explode('/', $$value) as $date) {
+        if (!empty($date) && !$date === '..') {
+          $error_message = $this->dateValidation($begin);
+          if ($error_message) {
+            $form_state->setError($element, $error_message);
+          }
+        }
       }
-      // End either empty or valid extended interval values (5.2.3.)
-      if (empty($end) || $end === 'unknown' || $end === 'open') {
-        return;
-      }
-      $error_message = $this->dateValidation($end);
-      if ($error_message) {
-        $form_state->setError($element, $error_message);
-      }
+      return;
     }
-    else {
-      $error_message = $this->dateValidation($value);
-      if ($error_message) {
-        $form_state->setError($element, $error_message);
-      }
+    // Single date (we assume at this point).
+    $error_message = $this->dateValidation($value);
+    if ($error_message) {
+      $form_state->setError($element, $error_message);
     }
   }
 
@@ -155,27 +178,38 @@ class EDTFWidget extends WidgetBase {
    *   False if valid or a string explaining the reason for invalidation.
    */
   protected function dateValidation($datetime_str) {
-
+    // TODO: Level 2 Unspecified Digits
     list($date, $time) = explode('T', $datetime_str);
 
     $date = trim($date);
-    $extended_year = (strpos($date, 'y') === 0 ? TRUE : FALSE);
-    if ($extended_year && $this->getSetting('strict_dates')) {
-      return "Extended years (5.2.4.) are not supported with the 'strict dates' option enabled.";
+    $extended_year = (strpos($date, 'Y') === 0 ? TRUE : FALSE);
+    if (&& $this->getSetting('strict_dates')) {
+      return "Extended years are not supported with the 'strict dates' option enabled.";
     }
-    // Uncertainty characters on the end are valid Level 1 features (5.2.1.),
-    // pull them off to make checking the rest easier.
-    $date = rtrim($date, '?~');
+    // Uncertainty characters on the end are valid Level 1 features.
+    // But only one should be used.
+    if (preg_match_all('/[~?%]/', $date) > 1) {
+      return "Only one uncertainty indicator ('~', '?', and '%') may be used per date."
+    }
 
     // Negative year? That is fine, but remove it
     // and the extended year indicator before exploding the date.
-    $date = ltrim($date, 'y-');
+    $date = ltrim($date, 'Y-');
 
     // Now to check the parts.
     list($year, $month, $day) = explode('-', $date, 3);
 
     // Year.
-    if (!preg_match('/^\d\d(\d\d|\du|uu)$/', $year) && !$extended_year) {
+    // Pull off uncertainty characters to make checking the rest easier.
+    $year = trim($year, '?~%');
+    // Trim significant digits.
+    $year = substr($year, 0, strpos($year, 'S'));
+    // Expand exponents.
+    if (strps($year, 'E') > 0) {
+      list($base, $exponent) = explode('E', $year);
+      $year = strval((10 ** intval($exponent)) * intval($base));
+    }
+    if (!$extended_year && !preg_match('/^\d\d(\d\d|\dX|XX)$/', $year)) {
       return "The year '$year' is invalid. Please enter a four-digit year.";
     }
     elseif ($extended_year && !preg_match('/^\d{5,}$/', $year)) {
@@ -184,22 +218,27 @@ class EDTFWidget extends WidgetBase {
     $strict_pattern = 'Y';
 
     // Month.
-    if (!empty($month) && !preg_match('/^(\d\d|\du|uu)$/', $month)) {
+    $month = trim($month, '?~%');
+    if (!empty($month) && !preg_match('/^(\d\d|\dX|XX)$/', $month)) {
       return "The month '$month' is invalid. Please enter a two-digit month.";
     }
     if (!empty($month)) {
-      if (strpos($year, 'u') !== FALSE && strpos($month, 'u') === FALSE) {
+      if (strpos($year, 'X') !== FALSE && strpos($month, 'X') === FALSE) {
         return "The month must either be blank or unspecified when the year is unspecified.";
+      }
+      if (strpos($month, 'X') === FALSE && !in_array(intval($month), array_merge(range(1, 12), range(21, 41)))) {
+        return "The specified month '$month' in '$datetime_str' is invalid.";
       }
       $strict_pattern = 'Y-m';
     }
 
     // Day.
-    if (!empty($day) && !preg_match('/^(\d\d|\du|uu)$/', $day)) {
+    $day = trim($day, '?~%');
+    if (!empty($day) && !preg_match('/^(\d\d|\dX|XX)$/', $day)) {
       return "The day '$day' is invalid. Please enter a two-digit day.";
     }
     if (!empty($day)) {
-      if (strpos($month, 'u') !== FALSE && strpos($day, 'u') === FALSE) {
+      if (strpos($month, 'X') !== FALSE && strpos($day, 'X') === FALSE) {
         return "The day must either be blank or unspecified when the month is unspecified.";
       }
       $strict_pattern = 'Y-m-d';
@@ -212,9 +251,8 @@ class EDTFWidget extends WidgetBase {
 
     if ($time) {
       if (!preg_match('/^-?(\d{4})(-\d{2}){2}T\d{2}(:\d{2}){2}(Z|(\+|-)\d{2}:\d{2})?$/', $datetime_str, $matches)) {
-        return "The date/time '$datetime_str' is invalid. See EDTF 1.0, 5.1.2.";
+        return "The date/time '$datetime_str' is invalid.";
       }
-      drupal_set_message(print_r($matches, TRUE));
       $strict_pattern = 'Y-m-d\TH:i:s';
       if (count($matches) > 4) {
         if ($matches[4] === 'Z') {
@@ -228,7 +266,7 @@ class EDTFWidget extends WidgetBase {
 
     if ($this->getSetting('strict_dates')) {
       // Clean the date/time string to ensure it parses correctly.
-      $cleaned_datetime = str_replace('u', '1', $datetime_str);
+      $cleaned_datetime = str_replace('X', '1', $datetime_str);
       $datetime_obj = DateTime::createFromFormat('!' . $strict_pattern, $cleaned_datetime);
       $errors = DateTime::getLastErrors();
       if (!$datetime_obj ||

--- a/src/Plugin/Field/FieldWidget/EDTFWidget.php
+++ b/src/Plugin/Field/FieldWidget/EDTFWidget.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\controlled_access_terms\Plugin\Field\FieldWidget;
 
-use Datetime;
 use Drupal\Core\Field\FieldItemListInterface;
 use Drupal\Core\Field\WidgetBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\controlled_access_terms\EDTFUtils;
 
 /**
  * Plugin implementation of the 'edtf' widget.
@@ -123,164 +123,12 @@ class EDTFWidget extends WidgetBase {
       $form_state->setValueForElement($element, '');
       return;
     }
-    // No whitespace.
-    if (preg_match('/\s/', $value) !== FALSE) {
-      $form_state->setError($element, t("Dates cannot include spaces."));
-      return;
-    }
-    // Sets.
-    if ($this->getSetting('sets')) {
-      if (strpos($value, '[') !== FALSE || strpos($value, '{') !== FALSE) {
-        // Test for valid enclosing characters and valid characters inside.
-        $match = preg_match('/^([\[,\{])[\d,\-,X,Y,E,S,.]*([\],\}])$/', $value);
-        if (!$match || $match[1] !== $match[2]) {
-          $form_state->setError($element, t("The set is improperly encoded."))
-        }
-        // Test each date in set.
-        foreach (preg_split('/(,|\.\.)/', trim($value, '{}[]')) as $date) {
-          $error_message = $this->dateValidation($date);
-          if ($error_message) {
-            $form_state->setError($element, $error_message);
-          }
-        }
-        return;
+    $errors = EDTFUtils::validate($value, $this->getSetting('intervals'), $this->getSetting('sets'), $this->getSetting('strict_dates'));
+    if (!empty($errors)) {
+      foreach ($errors as $err) {
+        $form_state->setError($element, $err);
       }
     }
-    // Intervals.
-    if ($this->getSetting('intervals')) {
-      if (strpos($value, 'T') !== FALSE) {
-        $form_state->setError($element, t("Date intervals cannot include times."));
-      }
-      foreach (explode('/', $$value) as $date) {
-        if (!empty($date) && !$date === '..') {
-          $error_message = $this->dateValidation($begin);
-          if ($error_message) {
-            $form_state->setError($element, $error_message);
-          }
-        }
-      }
-      return;
-    }
-    // Single date (we assume at this point).
-    $error_message = $this->dateValidation($value);
-    if ($error_message) {
-      $form_state->setError($element, $error_message);
-    }
-  }
-
-  /**
-   * Validate a date.
-   *
-   * @param string $datetime_str
-   *   The datetime string.
-   *
-   * @return bool|string
-   *   False if valid or a string explaining the reason for invalidation.
-   */
-  protected function dateValidation($datetime_str) {
-    // TODO: Level 2 Unspecified Digits
-    list($date, $time) = explode('T', $datetime_str);
-
-    $date = trim($date);
-    $extended_year = (strpos($date, 'Y') === 0 ? TRUE : FALSE);
-    if (&& $this->getSetting('strict_dates')) {
-      return "Extended years are not supported with the 'strict dates' option enabled.";
-    }
-    // Uncertainty characters on the end are valid Level 1 features.
-    // But only one should be used.
-    if (preg_match_all('/[~?%]/', $date) > 1) {
-      return "Only one uncertainty indicator ('~', '?', and '%') may be used per date."
-    }
-
-    // Negative year? That is fine, but remove it
-    // and the extended year indicator before exploding the date.
-    $date = ltrim($date, 'Y-');
-
-    // Now to check the parts.
-    list($year, $month, $day) = explode('-', $date, 3);
-
-    // Year.
-    // Pull off uncertainty characters to make checking the rest easier.
-    $year = trim($year, '?~%');
-    // Trim significant digits.
-    $year = substr($year, 0, strpos($year, 'S'));
-    // Expand exponents.
-    if (strps($year, 'E') > 0) {
-      list($base, $exponent) = explode('E', $year);
-      $year = strval((10 ** intval($exponent)) * intval($base));
-    }
-    if (!$extended_year && !preg_match('/^\d\d(\d\d|\dX|XX)$/', $year)) {
-      return "The year '$year' is invalid. Please enter a four-digit year.";
-    }
-    elseif ($extended_year && !preg_match('/^\d{5,}$/', $year)) {
-      return "Invalid extended year. Please enter at least a four-digit year.";
-    }
-    $strict_pattern = 'Y';
-
-    // Month.
-    $month = trim($month, '?~%');
-    if (!empty($month) && !preg_match('/^(\d\d|\dX|XX)$/', $month)) {
-      return "The month '$month' is invalid. Please enter a two-digit month.";
-    }
-    if (!empty($month)) {
-      if (strpos($year, 'X') !== FALSE && strpos($month, 'X') === FALSE) {
-        return "The month must either be blank or unspecified when the year is unspecified.";
-      }
-      if (strpos($month, 'X') === FALSE && !in_array(intval($month), array_merge(range(1, 12), range(21, 41)))) {
-        return "The specified month '$month' in '$datetime_str' is invalid.";
-      }
-      $strict_pattern = 'Y-m';
-    }
-
-    // Day.
-    $day = trim($day, '?~%');
-    if (!empty($day) && !preg_match('/^(\d\d|\dX|XX)$/', $day)) {
-      return "The day '$day' is invalid. Please enter a two-digit day.";
-    }
-    if (!empty($day)) {
-      if (strpos($month, 'X') !== FALSE && strpos($day, 'X') === FALSE) {
-        return "The day must either be blank or unspecified when the month is unspecified.";
-      }
-      $strict_pattern = 'Y-m-d';
-    }
-
-    // Time.
-    if (strpos($datetime_str, 'T') !== FALSE && empty($time)) {
-      return "Time not provided with time seperator (T).";
-    }
-
-    if ($time) {
-      if (!preg_match('/^-?(\d{4})(-\d{2}){2}T\d{2}(:\d{2}){2}(Z|(\+|-)\d{2}:\d{2})?$/', $datetime_str, $matches)) {
-        return "The date/time '$datetime_str' is invalid.";
-      }
-      $strict_pattern = 'Y-m-d\TH:i:s';
-      if (count($matches) > 4) {
-        if ($matches[4] === 'Z') {
-          $strict_pattern .= '\Z';
-        }
-        else {
-          $strict_pattern .= 'P';
-        }
-      }
-    }
-
-    if ($this->getSetting('strict_dates')) {
-      // Clean the date/time string to ensure it parses correctly.
-      $cleaned_datetime = str_replace('X', '1', $datetime_str);
-      $datetime_obj = DateTime::createFromFormat('!' . $strict_pattern, $cleaned_datetime);
-      $errors = DateTime::getLastErrors();
-      if (!$datetime_obj ||
-          !empty($errors['warning_count']) ||
-          // DateTime will create valid dates from Y-m without warning,
-          // so validate we still have what it was given.
-          !($cleaned_datetime === $datetime_obj->format($strict_pattern))
-        ) {
-        return "Strictly speaking, the date (and/or time) '$datetime_str' is invalid.";
-      }
-
-    }
-
-    return FALSE;
   }
 
 }

--- a/src/Plugin/Field/FieldWidget/EDTFWidget.php
+++ b/src/Plugin/Field/FieldWidget/EDTFWidget.php
@@ -125,9 +125,7 @@ class EDTFWidget extends WidgetBase {
     }
     $errors = EDTFUtils::validate($value, $this->getSetting('intervals'), $this->getSetting('sets'), $this->getSetting('strict_dates'));
     if (!empty($errors)) {
-      foreach ($errors as $err) {
-        $form_state->setError($element, $err);
-      }
+      $form_state->setError($element, implode("\n", $errors));
     }
   }
 


### PR DESCRIPTION
**GitHub Issue**: /[Islandora-CLAW/CLAW/issues/995](https://github.com/Islandora-CLAW/CLAW/issues/995)

# What does this Pull Request do?

Fixes the Widget and Formatter for the EDTF Field Type to match [the 2018 spec](https://www.loc.gov/standards/datetime/edtf.html).

# What's new?
* Adds an EDTFUtils class to consolidate EDTF-related code.
* Updates the validation code (now in EDTFUtils) to meet the 2018 spec.
* Updates the Widget and Formatter to use EDTFUtils and meet the spec.
* Adds an update hook to bring existing content in EDTF fields to meet the 2018 spec.

# How should this be tested?
* Take a site with controlled_access_terms enabled and add some content to EDTF fields (repository items, taxonomy terms, whatever). They all comply with the 2012 spec.
* Apply the PR
* Run updates (either 'siteurl/update.php' or `drush updb -y`)
* Clear cache.
* Check your content. All the values should display correctly (even if exact wording and display has been adjusted) and viewing them in the edit window should show new signifiers. E.g. '?~' is now '%' and unspecified values 'u' are now 'X'. 

# Interested parties
@Islandora-CLAW/committers