### PR TITLE
bump geolocation version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "drupal/auto_entitylabel": "^2.1@beta",
     "drupal/name": "^1.0@RC",
-    "drupal/geolocation": "^2.0",
+    "drupal/geolocation": "^3.0.0-rc1",
     "drupal/token": "^1.3"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   "require": {
     "drupal/auto_entitylabel": "^2.1@beta",
     "drupal/name": "^1.0@RC",
-    "drupal/geolocation": "^3.0.0-rc1",
+    "drupal/geolocation": "^3.0",
     "drupal/token": "^1.3"
   },
   "require-dev": {


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1077

# What does this Pull Request do?

Bumps the Drupal geolocation module up from the now unsupported version, 2.0, to the new supported version, 3.0.0-rc1.

# What's new?

* Bumps geolocation version in composer.json

# How should this be tested?

1. Clone Claw Playbook
1. Update inventory/vagrant/group_vars/webserver/drupal.yml: change `islandora/islandora_demo:dev-8.x-1.x` to `islandora/islandora_demo:dev-issue-1077` (This will target the controlled access terms branch with the new geolocation module version.)
1. `vagrant up`
1. Check to ensure geolocation is now version 8.x-3.0-rc1.
1. Play with Geographic Location taxonomy terms to make sure it works. E.g. 
    1. I added a Las Vegas term with the appropriate latitude and longitude, 
    1. I enabled the Geolocation Leaflet submodule
    1. I configured the Geographic Location vocabulary's display mode to use the Leaflet map
    1. Viewing the Las Vegas term successfully displayed a map with a marker in the center of Las Vegas.

# Interested parties
@Islandora-CLAW/committers and @kayakr