### PR TITLE
Remove PHP warning by removing array type hint

### DIFF
--- a/src/EDTFConverter.php
+++ b/src/EDTFConverter.php
@@ -40,7 +40,7 @@ class EDTFConverter extends CommonDataConverter {
    * @return string
    *   Returns the ISO 8601 date.
    */
-  public static function dateIso8601Value(array $data) {
+  public static function dateIso8601Value($data) {
 
     return explode('T', EDTFConverter::datetimeIso8601Value($data))[0];
 


### PR DESCRIPTION
Warning: Declaration of Drupal\controlled_access_terms\EDTFConverter::dateIso8601Value(array $data) should be compatible with Drupal\rdf\CommonDataConverter::dateIso8601Value($data) in require() (line 10 of modules/contrib/controlled_access_terms/src/EDTFConverter.php).