### PR TITLE
fix warnings and notices for year-only dates and CommonDataConverter mismatch

### DIFF
--- a/src/EDTFConverter.php
+++ b/src/EDTFConverter.php
@@ -14,13 +14,13 @@ class EDTFConverter extends CommonDataConverter {
    *
    * It assumes the earliest valid date for approximations and intervals.
    *
-   * @param array $data
+   * @param mixed $data
    *   The array containing the 'value' element.
    *
    * @return string
    *   Returns the ISO 8601 timestamp.
    */
-  public static function datetimeIso8601Value(array $data) {
+  public static function datetimeIso8601Value($data) {
 
     // Take first possible date.
     $date = preg_split('/(,|\.\.|\/)/', trim($data['value'], '{}[]'))[0];
@@ -34,13 +34,13 @@ class EDTFConverter extends CommonDataConverter {
    *
    * It assumes the earliest valid date for approximations and intervals.
    *
-   * @param array $data
+   * @param mixed $data
    *   The array containing the 'value' element.
    *
    * @return string
    *   Returns the ISO 8601 date.
    */
-  public static function dateIso8601Value(array $data) {
+  public static function dateIso8601Value($data) {
 
     return explode('T', EDTFConverter::datetimeIso8601Value($data))[0];
 

--- a/src/EDTFUtils.php
+++ b/src/EDTFUtils.php
@@ -333,7 +333,10 @@ class EDTFUtils {
     $month = '';
     $day = '';
 
-    $parsed_date[EDTFUtils::YEAR_BASE] = EDTFUtils::expandYear($parsed_date[EDTFUtils::YEAR_FULL], $parsed_date[EDTFUtils::YEAR_BASE], $parsed_date[EDTFUtils::YEAR_EXPONENT]);
+    // Expand the year if the Year Exponent exists.
+    if (array_key_exists(EDTFUtils::YEAR_EXPONENT, $parsed_date) && !empty($parsed_date[EDTFUtils::YEAR_EXPONENT])) {
+      $parsed_date[EDTFUtils::YEAR_BASE] = EDTFUtils::expandYear($parsed_date[EDTFUtils::YEAR_FULL], $parsed_date[EDTFUtils::YEAR_BASE], $parsed_date[EDTFUtils::YEAR_EXPONENT]);
+    }
 
     // Clean-up unspecified year/decade.
     $year = str_replace('X', '0', $parsed_date[EDTFUtils::YEAR_BASE]);

--- a/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/EDTFFormatter.php
@@ -197,6 +197,9 @@ class EDTFFormatter extends FormatterBase {
    */
   protected function formatDate($edtf_text) {
 
+    $settings = $this->getSettings();
+
+    // Separate into date and time components.
     $date_time = explode('T', $edtf_text);
 
     // Formatted versions of the date elements.
@@ -206,8 +209,10 @@ class EDTFFormatter extends FormatterBase {
 
     preg_match(EDTFUtils::DATE_PARSE_REGEX, $date_time[0], $parsed_date);
 
-    $parsed_date[EDTFUtils::YEAR_BASE] = EDTFUtils::expandYear($parsed_date[EDTFUtils::YEAR_FULL], $parsed_date[EDTFUtils::YEAR_BASE], $parsed_date[EDTFUtils::YEAR_EXPONENT]);
-    $settings = $this->getSettings();
+    // Expand the year if the Year Exponent exists.
+    if (array_key_exists(EDTFUtils::YEAR_EXPONENT, $parsed_date) && !empty($parsed_date[EDTFUtils::YEAR_EXPONENT])) {
+      $parsed_date[EDTFUtils::YEAR_BASE] = EDTFUtils::expandYear($parsed_date[EDTFUtils::YEAR_FULL], $parsed_date[EDTFUtils::YEAR_BASE], $parsed_date[EDTFUtils::YEAR_EXPONENT]);
+    }
 
     // Unspecified.
     $unspecified = [];


### PR DESCRIPTION
**GitHub Issue**: /Islandora-CLAW/CLAW/issues/1123

* supersedes #27 

# What does this Pull Request do?

Fixes the notices reported when formatting year-only dates (e.g. '2019'). Also fixes the warning from EDTFConverter::dateIso8601Value using the array type hint while CommonDataConverter: dateIso8601Value does not.

# What's new?

* Removes array type hint from EDTFConverter::dateIso8601Value and changes the doc from 'array' to 'mixed'.
* Changes EDTFUtils::iso8601Value and EDTFFormatter to check for a Year exponent before attempting to expand it.
* Does this change require documentation to be updated? No.
* Does this change add any new dependencies? No.
* Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? No.

# How should this be tested?

* Create a node or term using an EDTF field with an EDTF value of a single year (e.g. '2019'). 
* View the node or term in the web ui and then as JSON-LD. 
* Check the recent log messages. You should see the same notices as reported in the original issue.
* Apply the PR
* Clear caches
* View the node or term again in the ui and JSON-LD
* Check the logs again; there should not be any new errors or notices.

# Additional notes:

Thanks to @kayakr for reporting the issue and the initial PR!

# Interested parties
@kayakr and @Islandora-CLAW/committers