### PR TITLE
De-CLAWing readme files in controlled access terms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Welcome!
 
-If you are reading this document then you are interested in contributing to the Islandora CLAW. All contributions are welcome: use-cases, documentation, code, patches, bug reports, feature requests, etc. You do not need to be a programmer to speak up!
+If you are reading this document then you are interested in contributing to the Islandora 8. All contributions are welcome: use-cases, documentation, code, patches, bug reports, feature requests, etc. You do not need to be a programmer to speak up!
 
 ## Workflows
 
@@ -8,7 +8,7 @@ The group meets each Wednesday at 1:00 PM Eastern. Meeting notes and announcemen
 
 ### Use cases
 
-If you would like to submit a use case to the Islandora CLAW project, please submit an issue [here](https://github.com/Islandora-CLAW/CLAW/issues/new) using the [Use Case template](https://github.com/Islandora-CLAW/CLAW/wiki/Use-Case-template), prepending "Use Case:" to the title of the issue.
+If you would like to submit a use case to the Islandora 8 project, please submit an issue [here](https://github.com/Islandora-CLAW/CLAW/issues/new) using the [Use Case template](https://github.com/Islandora-CLAW/CLAW/wiki/Use-Case-template), prepending "Use Case:" to the title of the issue.
 
 ### Documentation
 
@@ -16,11 +16,11 @@ You can contribute documentation in two different ways. One way is to create an 
 
 ### Request a new feature
 
-To request a new feature you should [open an issue in the CLAW repository](https://github.com/Islandora-CLAW/CLAW/issues/new) or create a use case (see the _Use cases_ section above), and summarize the desired functionality. Prepend "Enhancement:" if creating an issue on the project repo, and "Use Case:" if creating a use case.
+To request a new feature you should [open an issue in the Islandora 8 repository](https://github.com/Islandora-CLAW/CLAW/issues/new) or create a use case (see the _Use cases_ section above), and summarize the desired functionality. Prepend "Enhancement:" if creating an issue on the project repo, and "Use Case:" if creating a use case.
 
 ### Report a bug
 
-To report a bug you should [open an issue in the CLAW repository](https://github.com/Islandora-CLAW/CLAW/issues/new) that summarizes the bug. Prepend the label "Bug:" to the title of the issue.
+To report a bug you should [open an issue in the Islandora 8 repository](https://github.com/Islandora-CLAW/CLAW/issues/new) that summarizes the bug. Prepend the label "Bug:" to the title of the issue.
 
 In order to help us understand and fix the bug it would be great if you could provide us with:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ subject terms.
 
 It is intended to be used in conjunction with both the [ArchivesSpace/Drupal 8
 Integration project](https://github.com/jasloe/archivesspace-drupal) and
-[Islandora CLAW](https://github.com/Islandora-CLAW/CLAW).
+[Islandora 8](https://github.com/Islandora-CLAW/CLAW).
 
 This module is under active development and will be in flux although master
 should always work (theoretically). There are some field naming inconsistencies


### PR DESCRIPTION
**GitHub Issue**: https://github.com/Islandora-CLAW/CLAW/issues/1082

# What does this Pull Request do?

Replaces references to Islandora CLAW in readme files with "Islandora 8." Does not go any deeper into the code to hunt down CLAWs.

# What's new?

Islandora CLAW -> Islandora 8 in controlled_access_terms readmes.

# How should this be tested?

Review and make sure I got'em all. 

# Additional Notes:

One PR of many.

# Interested parties
@Islandora-CLAW/committers