### PR TITLE
Create PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+**GitHub Issue**: (link)
+
+* Other Relevant Links (Google Groups discussion, related pull requests,
+ Release pull requests, etc.)
+
+# What does this Pull Request do?
+
+A brief description of what the intended result of the PR will be and/or what
+ problem it solves.
+
+# What's new?
+A in-depth description of the changes made by this PR. Technical details and
+ possible side effects.
+
+* Changes x feature to such that y
+* Added x
+* Removed y
+* Does this change require documentation to be updated? 
+* Does this change add any new dependencies? 
+* Does this change require any other modifications to be made to the repository
+ (ie. Regeneration activity, etc.)? 
+* Could this change impact execution of existing code?
+
+# How should this be tested?
+
+A description of what steps someone could take to:
+* Reproduce the problem you are fixing (if applicable)
+* Test that the Pull Request does what is intended.
+* Please be as detailed as possible.
+* Good testing instructions help get your PR completed faster.
+
+# Additional Notes:
+Any additional information that you think would be helpful when reviewing this
+ PR.
+
+# Interested parties
+Tag (@ mention) interested parties or, if unsure, @Islandora-CLAW/committers


### PR DESCRIPTION
* Other Relevant Links : previous PR to undo my doing this incorrectly: https://github.com/Islandora-CLAW/controlled_access_terms/pull/32

# What does this Pull Request do?

Adds the standard pull request template for repos in the CLAW org. 

# What's new?
PULL_REQUEST_TEMPLATE.md has been added.

# How should this be tested?

Verify the template is correct. Compare to https://github.com/Islandora-CLAW/CLAW/blob/master/.github/PULL_REQUEST_TEMPLATE.md

# Interested parties
@dannylamb 
